### PR TITLE
Fix "Cleartext HTTP traffic not permitted" on Android9,10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
 
         <!-- Splash screen -->


### PR DESCRIPTION
Adding this will fix downloading contents on Android 9 and 10.
Starting with Android 9 (API level 28), cleartext support is disabled by default.