### PR TITLE
PreEstabilishedSystemTitle null

### DIFF
--- a/Java/DLMS/src/main/java/gurux/dlms/secure/GXDLMSSecureClient.java
+++ b/Java/DLMS/src/main/java/gurux/dlms/secure/GXDLMSSecureClient.java
@@ -163,5 +163,6 @@ public class GXDLMSSecureClient extends GXDLMSClient {
      */
     public void setServerSystemTitle(final byte[] value) {
         getSettings().setSourceSystemTitle(value);
+        getSettings().setPreEstablishedSystemTitle(value);
     }
 }


### PR DESCRIPTION
Description of the issue:

In the .NET implementation, when the ServerSystemTitle is set, the PreEstablishedSystemTitle is automatically updated. However, this behavior is not present in the Java version.

.NET reference:
https://github.com/Gurux/Gurux.DLMS.Net/blob/c4290171bdc67d51949c9b9de2be1aa9aee30e27/Development/Secure/GXDLMSSecureClient.cs#L165

Java reference:
https://github.com/Gurux/Gurux.DLMS.Android/blob/2f01fa4987df6294175a08fef8bc2b4d3538a8e1/Java/DLMS/src/main/java/gurux/dlms/GXDLMS.java#L1493-L1495

Additionally, in Java, it's not possible to use general protection under certain conditions, as highlighted in the provided link.
Proposed solution:

    Align the Java behavior with the .NET version by ensuring that setting the ServerSystemTitle also updates the PreEstablishedSystemTitle.
